### PR TITLE
Adds minor correction to volume mounting syntax in the documentation

### DIFF
--- a/docs/resources/cluster.md
+++ b/docs/resources/cluster.md
@@ -213,6 +213,6 @@ Required:
 Optional:
 
 - `node_filters` (List of String)
-- `source` (String) Source path of volume mount
+- `source` (String) Source path of volume mount. This value should be suffixed with a colon; so for ``--volume /host/foo:/node/bar``, this value would be ``/host/foo:``.
 
 


### PR DESCRIPTION
This tidbit was unfortunately not specified in the documentation, and some people (myself included) might interpret this as only needing the actual path.

This might be a bug in parsing the string, but I don't know Go well enough to make a patch for that myself.